### PR TITLE
Build Oracle instant client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ One-off patches: It won't work with one-off patches as it's not designed for tha
 <br/>
 The module will use opatchauto if the Oracle home being patched is grid infrastructure, otherwise it will use standard opatch steps.<br/>
 <br/>
-The patching is customizable via role's variables definition. For example, you can run just prerequisites without applying the patch, patch binaries without database dictionary changes, skip the OJVM patch etc.<br/>
+The patching is customizable via role's variables definition. For example, you can run just prerequisites without applying the patch, patch binaries without database dictionary changes, skip the OJVM patch, build instant client packages, etc.<br/>
 <br/>
 The module supports 11g, 12c, 18c and 19c database versions. It should work properly on 10g as well, but I haven't tested it.<br/>
 <br/>
@@ -128,6 +128,8 @@ ora_home_list:
     host: -> It allows the user to specify a mapping to specific host for which this list entry is valid. It's applicable only if the playbook is executed against group of hosts
     backup_oh: -> Indicator whether to backup oracle home binaries (True/False)
     skip: -> Main indicator whether to skip this item or not
+    build_client -> Indicator whether to build instant client packages and libraries
+    build_client_only -> Indicator to only build instant client packages and libraries
     debug: -> Enables debug mode (True/False)
 ```
 

--- a/roles/orapatch/tasks/main.yml
+++ b/roles/orapatch/tasks/main.yml
@@ -46,7 +46,7 @@
           with_items:
             - "{{ ora_home_list }}"
           register: reg_check_opatch_min_version
-          when: not item.skip and (reg_check_opatch_min_version is not defined or "[orapatch] module fail" not in reg_check_opatch_min_version.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only
+          when: not item.skip and (reg_check_opatch_min_version is not defined or "[orapatch] module fail" not in reg_check_opatch_min_version.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only and not item.build_client_only
 
         - name: "Check conflicts against OH"
           orapatch:
@@ -59,7 +59,7 @@
           environment:
             TWO_TASK: ""
           register: reg_check_conflict_against_oh
-          when: not item.skip and (reg_check_conflict_against_oh is not defined or "[orapatch] module fail" not in reg_check_conflict_against_oh.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only
+          when: not item.skip and (reg_check_conflict_against_oh is not defined or "[orapatch] module fail" not in reg_check_conflict_against_oh.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only and not item.build_client_only
 
         - name: "Patch OH"
           orapatch:
@@ -72,7 +72,7 @@
           environment:
             TWO_TASK: ""
           register: reg_patch_oh
-          when: not patch_only_db_dict and not item.skip and not item.run_only_checks and (reg_patch_oh is not defined or "[orapatch] module fail" not in reg_patch_oh.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only
+          when: not patch_only_db_dict and not item.skip and not item.run_only_checks and (reg_patch_oh is not defined or "[orapatch] module fail" not in reg_patch_oh.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only and not item.build_client_only
 
         - name: "Patch DB"
           orapatch:
@@ -85,7 +85,7 @@
           environment:
             TWO_TASK: ""
           register: reg_patch_db
-          when: not item.patch_only_oh and not item.skip and not item.run_only_checks and (reg_patch_db is not defined or "[orapatch] module fail" not in reg_patch_db.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only
+          when: not item.patch_only_oh and not item.skip and not item.run_only_checks and (reg_patch_db is not defined or "[orapatch] module fail" not in reg_patch_db.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only and not item.build_client_only
 
         - name: "Patch OH OJVM"
           orapatch:
@@ -98,7 +98,7 @@
           environment:
             TWO_TASK: ""
           register: reg_patch_oh_ojvm
-          when: not patch_only_db_dict and not item.skip and not item.run_only_checks and item.patch_ojvm and (reg_patch_oh_ojvm is not defined or "[orapatch] module fail" not in reg_patch_oh_ojvm.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only
+          when: not patch_only_db_dict and not item.skip and not item.run_only_checks and item.patch_ojvm and (reg_patch_oh_ojvm is not defined or "[orapatch] module fail" not in reg_patch_oh_ojvm.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only and not item.build_client_only
 
         - name: "Patch DB OJVM"
           orapatch:
@@ -109,7 +109,46 @@
           with_items:
             - "{{ ora_home_list }}"
           register: reg_patch_db_ojvm
-          when: not item.patch_only_oh and not item.skip and not item.run_only_checks and item.patch_ojvm and (reg_patch_db_ojvm is not defined or "[orapatch] module fail" not in reg_patch_db_ojvm.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only
+          when: not item.patch_only_oh and not item.skip and not item.run_only_checks and item.patch_ojvm and (reg_patch_db_ojvm is not defined or "[orapatch] module fail" not in reg_patch_db_ojvm.msg) and ((item.host is defined and ansible_hostname == item.host) or (item.host is not defined or not item.host)) and not run_oh_backup_only and not item.build_client_only
+
+        - name: Build instant client
+          vars:
+            client_path: 'rdbms/install/instantclient/light'
+
+          block:
+            - name: Remove directory
+              file:
+                path: '{{ item.oracle_home_path }}/{{ client_path }}'
+                state: absent
+              with_items:
+                - "{{ ora_home_list }}"
+
+            - name: Create directory
+              file:
+                path: '{{ item.oracle_home_path }}/{{ client_path }}'
+                state: directory
+                mode: '0755'
+                owner: "{{ item.oracle_owner }}"
+                group: "{{ item.oracle_owner }}"
+              with_items:
+                - "{{ ora_home_list }}"
+
+            - name: Build zip and RPM files
+              become_user: "{{ item.oracle_owner }}"
+              become: true
+              shell:
+                cmd: |
+                  make -f ins_rdbms.mk igenliboci
+                  make -f ins_rdbms.mk ic_all_zip
+                chdir: '{{ item.oracle_home_path }}/rdbms/lib'
+              environment:
+                ORACLE_HOME: '{{ item.oracle_home_path }}'
+                LD_LIBRARY_PATH: '{{ item.oracle_home_path }}/lib'
+              with_items:
+                - "{{ ora_home_list }}"
+          when: item.build_client
+          become: true
+          become_user: "{{ item.oracle_owner }}"
 
     always:
         - name: "[SYSTEM] End logger session"

--- a/roles/orapatch/vars/main.yml
+++ b/roles/orapatch/vars/main.yml
@@ -15,4 +15,6 @@
       patch_db_list: "" # Comma separated list of db_unique_names
       host:
       backup_oh: False # Indicator whether to backup oracle home
+      build_client: True # Build instant client
+      build_client_only: False
       skip: False


### PR DESCRIPTION
Added task to build Oracle instant client zip and RPMs. See [About Rebuilding Oracle Instant Client Packages and Libraries](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/regenerating-library-zip-rpm.html#GUID-70689BE2-5746-4A17-B57A-158030363232).